### PR TITLE
Added toString methods to LineColumn return type. (Used in fromIndex)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.1",
   "description": "Convert index in a string to line/column",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/vneenz/licofi"
+    "type": "git",
+    "url": "https://github.com/vneenz/licofi"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,17 @@
 
-interface LineColumn {
+interface AbstractLineColumn {
     line: number;
     column: number;
+}
+
+class LineColumn implements AbstractLineColumn {
+    public constructor(public line: number, public column: number) {}
+    public toString() {
+        return this.line + ":" + this.column
+    }
+    public toVerboseString() {
+        return "Line: " + this.line + ", Column: " + this.column
+    }
 }
 
 interface Options {
@@ -39,7 +49,7 @@ function findClosestIndex(needle: number, haystack: number[]) {
     }
 }
 
-class LineColumnFinder {
+export class LineColumnFinder {
 
     private source: string;
     private options: Required<Options>;
@@ -67,7 +77,7 @@ class LineColumnFinder {
         }
     }
 
-    fromLineColumn(from: LineColumn) {
+    fromLineColumn(from: AbstractLineColumn) {
         const line = from.line - this.options.origin;
         const column = from.column - this.options.origin;
 
@@ -102,14 +112,13 @@ class LineColumnFinder {
         const line = findClosestIndex(index, this.lineCache);
         const column = index - this.lineCache[line];
 
-        return {
-            line: line + this.options.origin,
-            column: column + this.options.origin
-        };
+
+        return new LineColumn(
+            line + this.options.origin,
+            column + this.options.origin
+        )
     }
 
 }
 
-export {
-    LineColumnFinder
-};
+export default LineColumn

--- a/tests/LineColumnFinder.spec.ts
+++ b/tests/LineColumnFinder.spec.ts
@@ -92,3 +92,15 @@ it("throws exception when invalid line/column is specified", () => {
     expect(() => finder.fromLineColumn({line: 2, column: 6})).toThrow();
     expect(() => finder.fromLineColumn({line: 1, column: 0})).toThrow();
 });
+
+it("toString of LineColumn reports correctly", () => {
+    const str = "hello\nworld";
+    const finder = new LineColumnFinder(str);
+
+
+    expect(finder.fromIndex(8).toString()).toBe("2:3")
+    expect(finder.fromIndex(2).toString()).toBe("1:3")
+    
+    expect(finder.fromIndex(1).toVerboseString()).toBe("Line: 1, Column: 2")
+    expect(finder.fromIndex(5).toVerboseString()).toBe("Line: 1, Column: 6")
+});


### PR DESCRIPTION
Enables the following: 

```js
finder.fromIndex(8).toString()           // 2:3
finder.fromIndex(5).toVerboseString())   // Line: 1, Column: 6
```