### PR TITLE
Add comparative benchmark

### DIFF
--- a/bench/comparison.js
+++ b/bench/comparison.js
@@ -1,0 +1,136 @@
+'use strict'
+
+const Benchmark = require('benchmark')
+const benchmarks = require('beautify-benchmark')
+const chalk = require('chalk')
+const shuffle = require('array-shuffle')
+
+const findLineColumn = require('find-line-column')
+const textBuffer = require('simple-text-buffer')
+const charProps = require('char-props')
+const stringPos = require('string-pos')
+const vfile = require('vfile')
+const vfileLocation = require('vfile-location')
+const linesAndColumns = require('lines-and-columns')['default']
+const vscode = require('vscode-textbuffer')
+const lineColumn = require('line-column')
+const licofi = require('../dist').LineColumnFinder
+
+const candidates = [
+  {
+    name: 'find-line-column',
+    lineAndCol: (text, target) => {
+      return () => findLineColumn(text, target)
+    }
+  },
+  {
+    name: 'simple-text-buffer',
+    lineAndCol: (text, target) => {
+      const buff = new textBuffer(text)
+      return () => buff.positionForCharacterIndex(target)
+    }
+  },
+  {
+    name: 'char-props',
+    lineAndCol: (text, target) => {
+      const cp = charProps(text)
+      return () => ({ line: cp.lineAt(target), column: cp.columnAt(target) })
+    }
+  },
+  {
+    name: 'string-pos',
+    lineAndCol: (text, target) => {
+      stringPos(text.short, 0)
+      return () => stringPos(text, target)
+    }
+  },
+  {
+    name: 'vfile-location',
+    lineAndCol: (text, target) => {
+      const vfl = vfileLocation(vfile(text))
+      return () => vfl.toPosition(target)
+    }
+  },
+  {
+    name: 'lines-and-columns',
+    lineAndCol: (text, target) => {
+      const lac = new linesAndColumns(text)
+      return () => lac.locationForIndex(target)
+    }
+  },
+  {
+    name: 'vscode-textbuffer',
+    lineAndCol: (text, target) => {
+      const pieceTreeTextBufferBuilder = new vscode.PieceTreeTextBufferBuilder()
+      pieceTreeTextBufferBuilder.acceptChunk(text)
+      const pieceTreeFactory = pieceTreeTextBufferBuilder.finish(true)
+      const pieceTree = pieceTreeFactory.create(1)
+      return () => pieceTree.getPositionAt(target)
+    }
+  },
+  {
+    name: 'line-column',
+    lineAndCol: (text, target) => {
+      const lc = lineColumn(text)
+      return () => lc.fromIndex(target)
+    }
+  },
+  {
+    name: 'licofi',
+    lineAndCol: (text, target) => {
+      const lcf = new licofi(text)
+      return () => lcf.fromIndex(target)
+    }
+  }
+]
+
+const createSuite = function (name, options) {
+  return Benchmark.Suite(name, options).on('start', function () {
+    return console.log(chalk.dim(name))
+  }).on('cycle', function () {
+    return benchmarks.add(arguments[0].target)
+  }).on('complete', function () {
+    return benchmarks.log()
+  })
+}
+
+const textCases = [
+  {
+    name: 'short',
+    lines: 5
+  },
+  {
+    name: 'medium',
+    lines: 50
+  },
+  {
+    name: 'long',
+    lines: 500
+  },
+  {
+    name: 'very long',
+    lines: 5000
+  }
+]
+
+const loremIpsum = 'Lorem ipsum dolor sit amet\nconsectetur adipiscing elit.\nSuspendisse id sem vel mi cursus facilisis vel ac arcu.\nNulla vulputate tortor eu ipsum bibendum rhoncus'
+
+for (let j = 0, len1 = textCases.length; j < len1; j++) {
+  const textCase = textCases[j]
+  const text = ((function () {
+    const results = []
+    for (let i = 0, k = 0, ref = textCase.lines; 1 <= ref ? k <= ref : k >= ref; i = 1 <= ref ? ++k : --k) {
+      results.push(shuffle(loremIpsum.split('\n')))
+    }
+    return results
+  })()).join('\n')
+  const len = text.length
+  const lines = stringPos(text, len).line
+  const target = Math.round(text.length / 2 + ((text.length / 2) * 0.34))
+  const suite = createSuite(textCase.name + ' text: ' + len + ' chars, ' + lines + ' lines')
+  for (let k = 0, len2 = candidates.length; k < len2; k++) {
+    const c = candidates[k]
+    suite.add(c.name, c.lineAndCol(text, target))
+  }
+  suite.run()
+}

--- a/bench/package-lock.json
+++ b/bench/package-lock.json
@@ -1,0 +1,259 @@
+{
+  "name": "licofi-benchmarks",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
+    },
+    "array-shuffle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-1.0.1.tgz",
+      "integrity": "sha1-fqSIKjVrS8pfVF4LblLq9tlxVXo=",
+      "dev": true
+    },
+    "atom-patch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/atom-patch/-/atom-patch-0.3.0.tgz",
+      "integrity": "sha1-4AesVctQCopmwtju96Q3XTFCj1Q=",
+      "dev": true,
+      "requires": {
+        "random-seed": "^0.2.0"
+      }
+    },
+    "beautify-benchmark": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/beautify-benchmark/-/beautify-benchmark-0.2.4.tgz",
+      "integrity": "sha1-MVHe8UwaLg0H/y5HaGHH7Q4a45s=",
+      "dev": true
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
+    "chalk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "char-props": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/char-props/-/char-props-0.1.5.tgz",
+      "integrity": "sha1-W5UvniDqIc0Iyn/hNaEPb+kcEJ4=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.0.1.tgz",
+      "integrity": "sha1-pS2QzAiVaZS+AId7/5cRAGJYLDU=",
+      "dev": true
+    },
+    "event-kit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.2.0.tgz",
+      "integrity": "sha1-Kd9Q3q49bUwcYkUbEJJfKGQekos=",
+      "dev": true
+    },
+    "find-line-column": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/find-line-column/-/find-line-column-0.5.2.tgz",
+      "integrity": "sha1-2wAjj/hoVRoYLnShA0FtKVqYyMo=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "line-column": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+      "integrity": "sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=",
+      "dev": true,
+      "requires": {
+        "isarray": "^1.0.0",
+        "isobject": "^2.0.0"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
+    },
+    "random-seed": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/random-seed/-/random-seed-0.2.0.tgz",
+      "integrity": "sha1-TRiJtG3ITvUjFs63dysM4KVE844=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
+    },
+    "simple-text-buffer": {
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/simple-text-buffer/-/simple-text-buffer-9.2.11.tgz",
+      "integrity": "sha1-ljQmgSSO3bjjtxKMYI4Q21jYdIo=",
+      "dev": true,
+      "requires": {
+        "atom-patch": "0.3.0",
+        "diff": "3.0.1",
+        "event-kit": "2.2.0",
+        "span-skip-list": "0.2.0"
+      }
+    },
+    "span-skip-list": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/span-skip-list/-/span-skip-list-0.2.0.tgz",
+      "integrity": "sha1-j0e1yfHUvqry+7pVsB7ary47VNE=",
+      "dev": true
+    },
+    "string-pos": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-pos/-/string-pos-1.0.0.tgz",
+      "integrity": "sha512-lauA/SSfjRal6oz0g+UZw9lSq3r+PrasetBhhC5+GRier4ppsPfHh4vSLye0KN6l6L2nlKKTqveGP1GAlPDauQ==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "vfile": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
+      "integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      }
+    },
+    "vfile-location": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.0.1.tgz",
+      "integrity": "sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ==",
+      "dev": true
+    },
+    "vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "vscode-textbuffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textbuffer/-/vscode-textbuffer-1.0.0.tgz",
+      "integrity": "sha512-zPaHo4urgpwsm+PrJWfNakolRpryNja18SUip/qIIsfhuEqEIPEXMxHOlFPjvDC4JgTaimkncNW7UMXRJTY6ow==",
+      "dev": true
+    }
+  }
+}

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "licofi-benchmarks",
+  "description": "licofi benchmarks",
+  "private": true,
+  "author": {
+    "name": "Vas Sudanagunta"
+  },
+  "scripts": {
+    "bench": "sudo nice -10 node --require source-map-support/register comparison.js"
+  },
+  "devDependencies": {
+    "@types/node": "^13.13.4",
+    "array-shuffle": "^1.0.1",
+    "benchmark": "^2.1.4",
+    "beautify-benchmark": "^0.2.4",
+    "chalk": "^4.0.0",
+    "char-props": "^0.1.5",
+    "find-line-column": "^0.5.2",
+    "line-column": "^1.0.2",
+    "lines-and-columns": "^1.1.6",
+    "simple-text-buffer": "^9.2.11",
+    "string-pos": "^1.0.0",
+    "vfile": "^4.1.0",
+    "vfile-location": "^3.0.1",
+    "vscode-textbuffer": "^1.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "bench": "npm --prefix bench run bench"
   },
   "keywords": [
     "search",


### PR DESCRIPTION
`licofi` is the fastest by far of 9 Javascript line/column indexers, as the results of this submitted comparative benchmark program show below. Yet `licofi` has near zero usage.  Many projects demanding speed would consider switching to licofi if this information was made available.
| package            |     speed (ops/sec) | npm downloads per week |
| ------------------ | ---------: | ---------------------: |
| find-line-column   |     11,565 |                 61,000 |
| simple-text-buffer |    118,135 |                    159 |
| char-props         |    582,859 |                 16,000 |
| string-pos         |  2,903,177 |                     17 |
| vfile-location     |  1,451,754 |              2,800,000 |
| lines-and-columns  |  1,571,599 |              6,500,000 |
| vscode-textbuffer  |  8,252,509 |                  8,000 |
| line-column        | 22,269,372 |                 20,000 |
| **licofi**             |  😍  31,663,220 |             🤔         1 |

I wrote this comparative benchmark in my hunt for the fastest line/column indexer.  I originally modified of @danielkalen's [string-pos](https://github.com/danielkalen/string-pos) benchmark, correcting a serious flaw that produced very misleading results (and thus a false claim of being the fastest). That PR (danielkalen/string-pos#1) has not been accepted 3 months after having been acknowledged as correct. So I decided to rewrite it from the ground up, and submit it to the fastest of the bunch, `licofi`. 

The benchmark is in its own `bench` subdirectory with its own `package.json` to minimize impact on the existing project. I used regular Javascript rather than Typescript also to avoid impacting the main project and avoid transpiling benchmark code to the `dist` directory.  (I could use `ts-node` if TS is strongly preferred. let me know.)

The benchmark tests four different input text sizes. Below are the results on my 8 year-old MacBook Air:

![bench comparison](https://user-images.githubusercontent.com/2830093/80345969-057f5b00-8838-11ea-9228-f76a8d1e7b4a.png)
