### PR TITLE
Improved veracity of benchmark; added memory bench 

### DIFF
--- a/bench/comparison.js
+++ b/bench/comparison.js
@@ -16,73 +16,130 @@ const vscode = require("vscode-textbuffer")
 const lineColumn = require("line-column")
 const licofi = require("../dist").LineColumnFinder
 
+
 const candidates = [
     {
         name: "find-line-column",
-        lineAndCol: (text, target) => {
-            return () => findLineColumn(text, target)
+        lineAndCol: (text, stochasticOffsets) => {
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                findLineColumn(text, stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     },
     {
         name: "simple-text-buffer",
-        lineAndCol: (text, target) => {
+        lineAndCol: (text, stochasticOffsets) => {
             const buff = new textBuffer(text)
-            return () => buff.positionForCharacterIndex(target)
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                buff.positionForCharacterIndex(stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     },
     {
         name: "char-props",
-        lineAndCol: (text, target) => {
+        lineAndCol: (text, stochasticOffsets) => {
             const cp = charProps(text)
-            return () => ({ line: cp.lineAt(target), column: cp.columnAt(target) })
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                cp.lineAt(stochasticOffsets[next])
+                cp.columnAt(stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     },
     {
         name: "string-pos",
-        lineAndCol: (text, target) => {
+        lineAndCol: (text, stochasticOffsets) => {
             stringPos(text.short, 0)
-            return () => stringPos(text, target)
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                stringPos(text, stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     },
     {
         name: "vfile-location",
-        lineAndCol: (text, target) => {
+        lineAndCol: (text, stochasticOffsets) => {
             const vfl = vfileLocation(vfile(text))
-            return () => vfl.toPosition(target)
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                vfl.toPosition(stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     },
     {
         name: "lines-and-columns",
-        lineAndCol: (text, target) => {
+        lineAndCol: (text, stochasticOffsets) => {
             const lac = new linesAndColumns(text)
-            return () => lac.locationForIndex(target)
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                lac.locationForIndex(stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     },
     {
         name: "vscode-textbuffer",
-        lineAndCol: (text, target) => {
+        lineAndCol: (text, stochasticOffsets) => {
             const pieceTreeTextBufferBuilder = new vscode.PieceTreeTextBufferBuilder()
             pieceTreeTextBufferBuilder.acceptChunk(text)
             const pieceTreeFactory = pieceTreeTextBufferBuilder.finish(true)
             const pieceTree = pieceTreeFactory.create(1)
-            return () => pieceTree.getPositionAt(target)
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                pieceTree.getPositionAt(stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     },
     {
         name: "line-column",
-        lineAndCol: (text, target) => {
+        lineAndCol: (text, stochasticOffsets) => {
             const lc = lineColumn(text)
-            return () => lc.fromIndex(target)
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                lc.fromIndex(stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     },
     {
         name: "licofi",
-        lineAndCol: (text, target) => {
+        lineAndCol: (text, stochasticOffsets) => {
             const lcf = new licofi(text)
-            return () => lcf.fromIndex(target)
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                lcf.fromIndex(stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
         }
     }
 ]
+
 
 const createSuite = function (name, options) {
     return Benchmark.Suite(name, options).on("start", function () {
@@ -93,6 +150,12 @@ const createSuite = function (name, options) {
         return benchmarks.log()
     })
 }
+
+
+function randomInt (min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min)
+}
+
 
 const textCases = [
     {
@@ -115,6 +178,7 @@ const textCases = [
 
 const loremIpsum = "Lorem ipsum dolor sit amet\nconsectetur adipiscing elit.\nSuspendisse id sem vel mi cursus facilisis vel ac arcu.\nNulla vulputate tortor eu ipsum bibendum rhoncus"
 
+
 for (let j = 0, len1 = textCases.length; j < len1; j++) {
     const textCase = textCases[j]
     const text = ((function () {
@@ -126,11 +190,17 @@ for (let j = 0, len1 = textCases.length; j < len1; j++) {
     })()).join("\n")
     const len = text.length
     const lines = stringPos(text, len).line
-    const target = Math.round(text.length / 2 + ((text.length / 2) * 0.34))
+
+    const numOffsets = Math.min(text.length * 2, 50000)
+    const stochasticOffsets = new Array(numOffsets)
+    for (let m = 0; m < numOffsets; m++) {
+        stochasticOffsets[m] = randomInt(0, text.length-1)
+    }
+
     const suite = createSuite(textCase.name + " text: " + len + " chars, " + lines + " lines")
     for (let k = 0, len2 = candidates.length; k < len2; k++) {
         const c = candidates[k]
-        suite.add(c.name, c.lineAndCol(text, target))
+        suite.add(c.name, c.lineAndCol(text, stochasticOffsets))
     }
     suite.run()
 }

--- a/bench/comparison.js
+++ b/bench/comparison.js
@@ -3,7 +3,6 @@
 const Benchmark = require("benchmark")
 const benchmarks = require("beautify-benchmark")
 const chalk = require("chalk")
-const shuffle = require("array-shuffle")
 
 const findLineColumn = require("find-line-column")
 const textBuffer = require("simple-text-buffer")
@@ -159,37 +158,79 @@ function randomInt (min, max) {
 
 const textCases = [
     {
+        name: "very short",
+        lines: 10
+    },
+    {
         name: "short",
-        lines: 5
+        lines: 100
     },
     {
         name: "medium",
-        lines: 50
+        lines: 1000
     },
     {
         name: "long",
-        lines: 500
+        lines: 10000
     },
     {
         name: "very long",
-        lines: 5000
+        lines: 100000
     }
 ]
 
-const loremIpsum = "Lorem ipsum dolor sit amet\nconsectetur adipiscing elit.\nSuspendisse id sem vel mi cursus facilisis vel ac arcu.\nNulla vulputate tortor eu ipsum bibendum rhoncus"
+const Macbeth =
+`That which hath made them drunk hath made me bold;
+What hath quench'd them hath given me fire.
+Hark! Peace!
+It was the owl that shriek'd, the fatal bellman,
+Which gives the stern'st good-night. He is about it:
+The doors are open; and the surfeited grooms
+Do mock their charge with snores: I have drugg'd 
+their possets,
+That death and nature do contend about them,
+Whether they live or die.
 
+[Within] Who's there? what, ho!
+
+Alack, I am afraid they have awaked,
+And 'tis not done. The attempt and not the deed
+Confounds us. Hark! I laid their daggers ready;
+He could not miss 'em. Had he not resembled
+My father as he slept, I had done't.
+
+*Enter MACBETH*
+
+My husband!
+
+I have done the deed. Didst thou not hear a noise?
+
+I heard the owl scream and the crickets cry.
+Did not you speak?
+
+When?
+
+Now.
+
+As I descended?
+
+Ay.`.split("\n")
+
+
+function generateText (lines) {
+    let buf = ''
+    const max = Macbeth.length - 1
+    for (let i = 0; i < lines; i++) {
+        buf += Macbeth[randomInt(0, max)]
+        buf += "\n"
+    }
+    return buf
+}
 
 for (let j = 0, len1 = textCases.length; j < len1; j++) {
     const textCase = textCases[j]
-    const text = ((function () {
-        const results = []
-        for (let i = 0, k = 0, ref = textCase.lines; 1 <= ref ? k <= ref : k >= ref; i = 1 <= ref ? ++k : --k) {
-            results.push(shuffle(loremIpsum.split("\n")))
-        }
-        return results
-    })()).join("\n")
-    const len = text.length
-    const lines = stringPos(text, len).line
+
+    const text = generateText(textCase.lines)
 
     const numOffsets = Math.min(text.length * 2, 50000)
     const stochasticOffsets = new Array(numOffsets)
@@ -197,7 +238,7 @@ for (let j = 0, len1 = textCases.length; j < len1; j++) {
         stochasticOffsets[m] = randomInt(0, text.length-1)
     }
 
-    const suite = createSuite(textCase.name + " text: " + len + " chars, " + lines + " lines")
+    const suite = createSuite(textCase.name + " text: " + text.length + " chars, " + textCase.lines + " lines")
     for (let k = 0, len2 = candidates.length; k < len2; k++) {
         const c = candidates[k]
         suite.add(c.name, c.lineAndCol(text, stochasticOffsets))

--- a/bench/comparison.js
+++ b/bench/comparison.js
@@ -57,19 +57,6 @@ const candidates = [
         }
     },
     {
-        name: "string-pos",
-        lineAndCol: (text, stochasticOffsets) => {
-            stringPos(text.short, 0)
-            let len = stochasticOffsets.length
-            let next = 0
-            return function() {
-                stringPos(text, stochasticOffsets[next])
-                next++
-                if (next === len) next = 0
-            }
-        }
-    },
-    {
         name: "vfile-location",
         lineAndCol: (text, stochasticOffsets) => {
             const vfl = vfileLocation(vfile(text))
@@ -90,6 +77,19 @@ const candidates = [
             let next = 0
             return function() {
                 lac.locationForIndex(stochasticOffsets[next])
+                next++
+                if (next === len) next = 0
+            }
+        }
+    },
+    {
+        name: "string-pos",
+        lineAndCol: (text, stochasticOffsets) => {
+            stringPos(text.short, 0)
+            let len = stochasticOffsets.length
+            let next = 0
+            return function() {
+                stringPos(text, stochasticOffsets[next])
                 next++
                 if (next === len) next = 0
             }

--- a/bench/comparison.js
+++ b/bench/comparison.js
@@ -141,12 +141,12 @@ const candidates = [
 
 
 const createSuite = function (name, options) {
-    return Benchmark.Suite(name, options).on("start", function () {
-        return console.log(chalk.dim(name))
-    }).on("cycle", function () {
-        return benchmarks.add(arguments[0].target)
+    return new Benchmark.Suite(name, options).on("start", function () {
+        console.log(chalk.blue(name))
+    }).on("cycle", function (event) {
+        benchmarks.add(event.target)
     }).on("complete", function () {
-        return benchmarks.log()
+        benchmarks.log()
     })
 }
 
@@ -227,7 +227,7 @@ function generateText (lines) {
     return buf
 }
 
-for (let j = 0, len1 = textCases.length; j < len1; j++) {
+for (let j = 0; j < textCases.length; j++) {
     const textCase = textCases[j]
 
     const text = generateText(textCase.lines)
@@ -239,9 +239,12 @@ for (let j = 0, len1 = textCases.length; j < len1; j++) {
     }
 
     const suite = createSuite(textCase.name + " text: " + text.length + " chars, " + textCase.lines + " lines")
-    for (let k = 0, len2 = candidates.length; k < len2; k++) {
+    for (let k = 0; k < candidates.length; k++) {
         const c = candidates[k]
-        suite.add(c.name, c.lineAndCol(text, stochasticOffsets))
+        suite.add(c.name, c.lineAndCol(text, stochasticOffsets), {
+            'onError': (event) => {console.log(c.name, "benchmark error:", event.target.error)},
+          }
+        )
     }
     suite.run()
 }

--- a/bench/package-lock.json
+++ b/bench/package-lock.json
@@ -182,6 +182,12 @@
       "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
       "dev": true
     },
+    "numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY=",
+      "dev": true
+    },
     "platform": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",

--- a/bench/package-lock.json
+++ b/bench/package-lock.json
@@ -160,6 +160,28 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "microtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/microtime/-/microtime-3.0.0.tgz",
+      "integrity": "sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==",
+      "dev": true,
+      "requires": {
+        "node-addon-api": "^1.2.0",
+        "node-gyp-build": "^3.8.0"
+      }
+    },
+    "node-addon-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+      "dev": true
+    },
+    "node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "dev": true
+    },
     "platform": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",

--- a/bench/package.json
+++ b/bench/package.json
@@ -6,23 +6,26 @@
     "name": "Vas Sudanagunta"
   },
   "scripts": {
-    "bench": "nice -10 node comparison.js"
+    "bench": "nice -10 node --expose-gc comparison.js",
+    "benchMem": "nice -10 node --expose-gc comparison.js -m"
   },
   "devDependencies": {
     "@types/node": "^13.13.4",
     "array-shuffle": "^1.0.1",
-    "benchmark": "^2.1.4",
     "beautify-benchmark": "^0.2.4",
+    "benchmark": "^2.1.4",
     "chalk": "^4.0.0",
     "char-props": "^0.1.5",
     "find-line-column": "^0.5.2",
     "line-column": "^1.0.2",
     "lines-and-columns": "^1.1.6",
     "microtime": "^3.0.0",
+    "numeral": "^2.0.6",
     "simple-text-buffer": "^9.2.11",
     "string-pos": "^1.0.0",
     "vfile": "^4.1.0",
     "vfile-location": "^3.0.1",
-    "vscode-textbuffer": "^1.0.0"
+    "vscode-textbuffer": "^1.0.0",
+    "sprintf-js": "latest"
   }
 }

--- a/bench/package.json
+++ b/bench/package.json
@@ -18,6 +18,7 @@
     "find-line-column": "^0.5.2",
     "line-column": "^1.0.2",
     "lines-and-columns": "^1.1.6",
+    "microtime": "^3.0.0",
     "simple-text-buffer": "^9.2.11",
     "string-pos": "^1.0.0",
     "vfile": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",
-    "bench": "npm --prefix bench run bench"
+    "bench": "npm --prefix bench run bench",
+    "benchMem": "npm --prefix bench run benchMem"
   },
   "keywords": [
     "search",


### PR DESCRIPTION
Fixed:
- previously was making the same exact call (same offset into text) for all benchmark iterations
- previous sample text was a poor sample, all lines long and of same length.

New:
- added memory usage benchmark:
   `npm run benchMem` or `node --expose-gc comparison.js -m`
 
   (The "query ms" column below is aggregate time for all 47476 queries)
   ```
   medium text (1000 lines), 47476 queries
                                kb   index ms   query ms    total ms
   find-line-column         11,643          0       6017        6017
   simple-text-buffer        6,461         11        469         480
   char-props                  479          0         94          94
   vfile-location              256          0         48          48
   lines-and-columns           203          4         51          55
   string-pos                  566          0         26          26
   vscode-textbuffer         2,368          5         23          28
   line-column                 491          0         12          12
   licofi                      277          1         12          13
   ```

See comments in individual commits for more details. It's also a lot easier to review the changes by commit, as they are clean.

![1](https://user-images.githubusercontent.com/2830093/80592441-7451e500-89ed-11ea-9977-13be447cdcea.png)

![2](https://user-images.githubusercontent.com/2830093/80592450-79169900-89ed-11ea-9e51-e7b72bafee31.png)
