### PR TITLE
Support import into ES6 modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ interface AbstractLineColumn {
     column: number;
 }
 
-class LineColumn implements AbstractLineColumn {
+export class LineColumn implements AbstractLineColumn {
     public constructor(public line: number, public column: number) {}
     public toString() {
         return this.line + ":" + this.column
@@ -120,5 +120,3 @@ export class LineColumnFinder {
     }
 
 }
-
-export default LineColumn

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "baseUrl": ".",
         "noEmitOnError": true,
         "module": "commonjs",
+        "esModuleInterop": true,
         "sourceMap": false,
         "noImplicitAny": true,
         "outDir": "dist",


### PR DESCRIPTION
Many projects are now written as ES6 Modules, not just because it is the future, but also because bundlers such as rollup and webpack can produce far smaller bundles from ES6 modules. When I converted my project, LineColumnFinder become impossible to import. See commit message below:

---

With this change, both LineColumn and LineColumnFinder are accessible from an ES6 module, as follows:

    import licofi from 'licofi'

    let finder = new licofi.LineColumnFinder(...)

    let licol = new licofi.LineColumn(...)

Because LineColumn was declared as the default export, it was impossible to import LineColumnFinder into an ES6 module. It didn't make sense that LineColumn was the default export
anyway. See https://nodejs.org/api/esm.html#esm_import_statements